### PR TITLE
Typo fix for the partition count exit atom

### DIFF
--- a/src/brucke_sup.erl
+++ b/src/brucke_sup.erl
@@ -100,7 +100,7 @@ get_partition_count({ClientId, Topic}) ->
     {error, 'UnknownTopicOrPartition'} ->
       none;
     {error, Reason} ->
-      exit({failed_to_get_partiton_count, ClientId, Topic, Reason})
+      exit({failed_to_get_partition_count, ClientId, Topic, Reason})
   end.
 
 -spec max_partitions_per_group_member(route_options()) -> pos_integer().


### PR DESCRIPTION
Just a minor typo I found while reading through the code. Not surprisingly I don't see anything that pattern matches against this atom so it'd just affect error output for an unusual edge condition.